### PR TITLE
Limit history entry number and age

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/PipelineConfigHistoryPurger.java
+++ b/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/PipelineConfigHistoryPurger.java
@@ -1,0 +1,17 @@
+package org.jenkinsci.plugins.pipelineConfigHistory;
+
+import hudson.model.PeriodicWork;
+
+public class PipelineConfigHistoryPurger extends PeriodicWork {
+
+  @Override
+  public long getRecurrencePeriod() {
+    //purge on a daily basis
+    return DAY;
+  }
+
+  @Override
+  protected void doRun() throws Exception {
+
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/PipelineConfigHistoryPurger.java
+++ b/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/PipelineConfigHistoryPurger.java
@@ -1,8 +1,25 @@
 package org.jenkinsci.plugins.pipelineConfigHistory;
 
+import hudson.Extension;
 import hudson.model.PeriodicWork;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.pipelineConfigHistory.model.PipelineConfigHistoryGlobalConfiguration;
+import org.jenkinsci.plugins.pipelineConfigHistory.model.PipelineItemHistoryDao;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Extension
 public class PipelineConfigHistoryPurger extends PeriodicWork {
+
+
+  /**
+   * This classes loger.
+   */
+  private static final Logger LOG =
+      Logger.getLogger(PipelineConfigHistoryPurger.class.getName());
 
   @Override
   public long getRecurrencePeriod() {
@@ -12,6 +29,23 @@ public class PipelineConfigHistoryPurger extends PeriodicWork {
 
   @Override
   protected void doRun() throws Exception {
+    //stateless, maxAge always comes from the global config.
+    Optional<Integer> maxAgeOptional = PipelineConfigHistoryGlobalConfiguration.get().getMaxDaysToKeepEntriesOptional();
+    if (!maxAgeOptional.isPresent()) return;
 
+    int maxAge = maxAgeOptional.get();
+    if (maxAge > 0) {
+      LOG.log(Level.FINE,
+          "checking for history files to purge (max age of {0} days allowed)",
+          maxAge);
+      purgeHistoryByAge(maxAge);
+    }
+  }
+
+  private void purgeHistoryByAge(int maxAge) {
+    PipelineItemHistoryDao pipelineItemHistoryDao = PluginUtils.getHistoryDao();
+    Jenkins.get().getAllItems(WorkflowJob.class).forEach( workflowJob ->
+        pipelineItemHistoryDao.purgeEntriesByAge(maxAge, workflowJob)
+    );
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/PluginUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/PluginUtils.java
@@ -29,6 +29,7 @@ import hudson.model.Item;
 import jenkins.model.Jenkins;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.pipelineConfigHistory.model.FilePipelineItemHistoryDao;
+import org.jenkinsci.plugins.pipelineConfigHistory.model.PipelineConfigHistoryGlobalConfiguration;
 import org.jenkinsci.plugins.pipelineConfigHistory.model.PipelineItemHistoryDao;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
@@ -49,6 +50,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -64,9 +66,18 @@ public final class PluginUtils {
    * @return the currently used history dao.
    */
   public static PipelineItemHistoryDao getHistoryDao() {
-    return new FilePipelineItemHistoryDao(
-        new File(Jenkins.get().getRootDir(), PipelineConfigHistoryConsts.DEFAULT_HISTORY_DIR)
-    );
+    Optional<Integer> maxHistoryEntriesOptional = PipelineConfigHistoryGlobalConfiguration.get().getMaxHistoryEntriesOptional();
+    if (maxHistoryEntriesOptional.isPresent()) {
+      return new FilePipelineItemHistoryDao(
+          new File(Jenkins.get().getRootDir(), PipelineConfigHistoryConsts.DEFAULT_HISTORY_DIR),
+          maxHistoryEntriesOptional.get()
+      );
+    } else {
+      return new FilePipelineItemHistoryDao(
+          new File(Jenkins.get().getRootDir(), PipelineConfigHistoryConsts.DEFAULT_HISTORY_DIR)
+      );
+    }
+
   }
 
   /**

--- a/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/model/FilePipelineItemHistoryDao.java
+++ b/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/model/FilePipelineItemHistoryDao.java
@@ -30,10 +30,12 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Optional;
@@ -52,6 +54,10 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 import org.xml.sax.SAXException;
+import sun.rmi.runtime.Log;
+
+import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.WARNING;
 
 /**
  * A PipelineItemHistoryDao-Implementation for storing the history directly in the file system
@@ -76,7 +82,8 @@ public class FilePipelineItemHistoryDao implements PipelineItemHistoryDao {
 
   public FilePipelineItemHistoryDao(final File historyRootDir, int maxHistoryEntries) {
     this.historyRootDir = historyRootDir;
-    this.maxHistoryEntries = maxHistoryEntries > 0 ? maxHistoryEntries : -1;
+    // 0+ is allowed
+    this.maxHistoryEntries = maxHistoryEntries >= 0 ? maxHistoryEntries : -1;
   }
 
   @Override
@@ -109,6 +116,10 @@ public class FilePipelineItemHistoryDao implements PipelineItemHistoryDao {
 
     LOG.log(Level.FINEST,
         hasSomethingChanged ? "Pipeline history was updated" : "Pipeline history was not updated.");
+
+    // delete old entries if there are too many.
+    // Calling this is only needed when incrementing the number of history entries.
+    purgeOldEntries(workflowJob);
     
     return hasSomethingChanged;
   }
@@ -358,19 +369,83 @@ public class FilePipelineItemHistoryDao implements PipelineItemHistoryDao {
     return getHistoryRootDirectory(workflowJob.getFullName());
   }
 
-  private void purgeOldEntries(WorkflowJob worflowJob) {
-    File historyRootDirectory = getHistoryRootDirectory(worflowJob);
+  @Override
+  public void purgeEntriesByAge(int maxAge, WorkflowJob workflowJob) {
+    File historyRootDirectory = getHistoryRootDirectory(workflowJob);
+    final File[] configurationDirectories = historyRootDirectory.listFiles(PipelineHistoryFileFilter.getInstance());
+
+    Arrays.stream(configurationDirectories).forEach( timestampedHistoryDir ->  {
+      if (isTooOld(maxAge, timestampedHistoryDir)) {
+        LOG.log(
+            FINEST,
+            "Deleting: {0}",
+            timestampedHistoryDir);
+
+        try {
+          FileUtils.deleteDirectory(timestampedHistoryDir);
+        } catch (IOException e) {
+          LOG.log(WARNING, "Deleting {0} failed: {1}",
+              new Object[] {timestampedHistoryDir, e.getMessage()});
+        }
+      }
+    });
+
+  }
+
+  /**
+   * Checks if the history directory is too old by parsing its name as a date
+   * and comparing it to the current date minus the maximal allowed age in
+   * days.
+   *
+   * @param historyDir
+   *            The history directory, e.g. 2013-01-18_17-33-51
+   * @return True if it is too old.
+   */
+  boolean isTooOld(int maxAge, File historyDir) {
+    Date parsedDate = null;
+    final SimpleDateFormat dateParser = new SimpleDateFormat(
+        PipelineConfigHistoryConsts.ID_FORMATTER);
+    try {
+      parsedDate = dateParser.parse(historyDir.getName());
+    } catch (ParseException ex) {
+      LOG.log(WARNING, "Unable to parse Date: {0}", ex);
+    }
+    final Calendar historyDate = new GregorianCalendar();
+    if (parsedDate != null) {
+      historyDate.setTime(parsedDate);
+      final Calendar oldestAllowedDate = new GregorianCalendar();
+      oldestAllowedDate.add(Calendar.DAY_OF_YEAR, - maxAge);
+      if (historyDate.before(oldestAllowedDate)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void purgeOldEntries(WorkflowJob workflowJob) {
+    File historyRootDirectory = getHistoryRootDirectory(workflowJob);
+    final File[] configurationDirectories = historyRootDirectory.listFiles(PipelineHistoryFileFilter.getInstance());
+    if (configurationDirectories == null) return;
+    int entryCount = configurationDirectories.length;
     if (this.hasMaxHistoryEntries()) {
+      String purgingStr =
+          entryCount > maxHistoryEntries
+              ? ", purging " + (entryCount - maxHistoryEntries) + " entries."
+              : "";
       LOG.log(
-          Level.FINE,
-          "checking for history files to purge ({0} max allowed)",
-          this.maxHistoryEntries
+          //Level.FINE,
+          Level.INFO,
+          "checking for history files to purge ({0} entries existing, {1} max allowed)"
+              + purgingStr,
+          new Object[]{configurationDirectories.length, this.maxHistoryEntries}
+          //this.maxHistoryEntries
       );
-      final File[] configurationDirectories = historyRootDirectory.listFiles(PipelineHistoryFileFilter.getInstance());
-      if (configurationDirectories != null && configurationDirectories.length > this.maxHistoryEntries) {
+      if (configurationDirectories.length > this.maxHistoryEntries) {
         Arrays.sort(configurationDirectories, Collections.reverseOrder());
         for (int i = this.maxHistoryEntries; i < configurationDirectories.length; ++i) {
-          LOG.log(Level.FINE,
+          LOG.log(
+              //Level.FINE,
+              Level.INFO,
               "purging old directory from history logs: {0}",
               configurationDirectories[i]
           );
@@ -390,7 +465,8 @@ public class FilePipelineItemHistoryDao implements PipelineItemHistoryDao {
   }
 
   private boolean hasMaxHistoryEntries() {
-    return maxHistoryEntries > 0;
+    //0 is allowed.
+    return maxHistoryEntries >= 0;
   }
 
   private final File getHistoryRootDirectory(String jobName) {

--- a/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/model/PipelineConfigHistoryGlobalConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/model/PipelineConfigHistoryGlobalConfiguration.java
@@ -1,0 +1,104 @@
+package org.jenkinsci.plugins.pipelineConfigHistory.model;
+
+
+import hudson.Extension;
+import hudson.util.FormValidation;
+import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.util.Optional;
+import javax.swing.text.html.Option;
+
+@Extension
+@SuppressWarnings("unused")
+public class PipelineConfigHistoryGlobalConfiguration extends GlobalConfiguration {
+
+  /** Maximum number of configuration history entries to keep. */
+  private String maxHistoryEntries;
+
+  /** Maximum number of days to keep entries. */
+  private String maxDaysToKeepEntries;
+
+
+  public PipelineConfigHistoryGlobalConfiguration() {
+    load();
+  }
+
+  public static PipelineConfigHistoryGlobalConfiguration get() {
+    return GlobalConfiguration.all().get(PipelineConfigHistoryGlobalConfiguration.class);
+  }
+
+  @Override
+  public boolean configure(StaplerRequest request, JSONObject formData) {
+
+    maxHistoryEntries = formData.getString("maxHistoryEntries").trim();
+    maxDaysToKeepEntries = formData.getString("maxDaysToKeepEntries").trim();
+
+    save();
+    return false;
+  }
+
+  public String getMaxHistoryEntries() { return maxHistoryEntries;}
+
+  public String getMaxDaysToKeepEntries() { return  maxDaysToKeepEntries;}
+
+
+  public Optional<Integer> getMaxHistoryEntriesOptional() {
+    try {
+      return Optional.of(Integer.parseInt(maxHistoryEntries));
+    } catch (NumberFormatException e) {
+      return Optional.empty();
+    }
+  }
+
+  public Optional<Integer> getMaxDaysToKeepEntriesOptional() {
+    try {
+      return Optional.of(Integer.parseInt(maxDaysToKeepEntries));
+    } catch (NumberFormatException e) {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Validates the user entry for the maximum number of history items to keep.
+   * Must be blank or a non-negative integer.
+   *
+   * @param value
+   *            The form input entered by the user.
+   * @return ok if the entry is blank or a non-negative integer.
+   */
+  public FormValidation doCheckMaxHistoryEntries(
+      @QueryParameter final String value) {
+    try {
+      if (StringUtils.isNotBlank(value) && Integer.parseInt(value) < 0) {
+        throw new NumberFormatException();
+      }
+      return FormValidation.ok();
+    } catch (NumberFormatException ex) {
+      return FormValidation.error("Enter a valid positive integer");
+    }
+  }
+
+  /**
+   * Validates the user entry for the maximum number of days to keep history
+   * items. Must be blank or a non-negative integer.
+   *
+   * @param value
+   *            The form input entered by the user.
+   * @return ok if the entry is blank or a non-negative integer.
+   */
+  public FormValidation doCheckMaxDaysToKeepEntries(
+      @QueryParameter final String value) {
+    try {
+      if (StringUtils.isNotBlank(value) && Integer.parseInt(value) < 0) {
+        throw new NumberFormatException();
+      }
+      return FormValidation.ok();
+    } catch (NumberFormatException ex) {
+      return FormValidation.error("Enter a valid positive integer");
+    }
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/model/PipelineItemHistoryDao.java
+++ b/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/model/PipelineItemHistoryDao.java
@@ -111,4 +111,6 @@ public interface PipelineItemHistoryDao {
    * @return whether there are history entries present or not
    */
   boolean isHistoryPresent(WorkflowJob workflowJob);
+
+  void purgeEntriesByAge(int maxAge, WorkflowJob workflowJob);
 }

--- a/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/model/PipelineConfigHistoryGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/model/PipelineConfigHistoryGlobalConfiguration/config.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+    <f:section title="${%title.configtitle}">
+        <f:entry title="${%Max number of history entries to keep}" help="/plugin/pipeline-config-history/help/help-maxHistoryEntries.html">
+            <f:textbox name="maxHistoryEntries" value="${it.maxHistoryEntries}" field="maxHistoryEntries"/>
+        </f:entry>
+        <f:entry title="${%Max number of days to keep history entries}" help="/plugin/pipeline-config-history/help/help-maxDaysToKeepEntries.html">
+            <f:textbox name="maxDaysToKeepEntries" value="${it.maxDaysToKeepEntries}" field="maxDaysToKeepEntries"/>
+        </f:entry>
+    </f:section>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/model/PipelineConfigHistoryGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/model/PipelineConfigHistoryGlobalConfiguration/config.jelly
@@ -2,10 +2,10 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
     <f:section title="${%title.configtitle}">
-        <f:entry title="${%Max number of history entries to keep}" help="/plugin/pipeline-config-history/help/help-maxHistoryEntries.html">
+        <f:entry title="${%Max number of history entries to keep}">
             <f:textbox name="maxHistoryEntries" value="${it.maxHistoryEntries}" field="maxHistoryEntries"/>
         </f:entry>
-        <f:entry title="${%Max number of days to keep history entries}" help="/plugin/pipeline-config-history/help/help-maxDaysToKeepEntries.html">
+        <f:entry title="${%Max number of days to keep history entries}">
             <f:textbox name="maxDaysToKeepEntries" value="${it.maxDaysToKeepEntries}" field="maxDaysToKeepEntries"/>
         </f:entry>
     </f:section>

--- a/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/model/PipelineConfigHistoryGlobalConfiguration/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/model/PipelineConfigHistoryGlobalConfiguration/config.properties
@@ -1,0 +1,1 @@
+title.configtitle=Pipeline Config History


### PR DESCRIPTION
Makes this plugin configurable in so far as that you
- can limit the number of history entries created per pipeline job.
- can limit the age of history entries for pipeline jobs.
