### PR TITLE
Fix every main script is called jenkinsfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file.
 * New feature: Make this plugin configurable in so far as that you
   + can limit the number of history entries created per pipeline job.
   + can limit the age of history entries for pipeline jobs.
+* Fixed: every root build file is called Jenkinsfile.
+* Fixed: missing name in "file view" links in diff overview page.
 
 
 ## [1.3] - 31.05.19

--- a/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/PluginUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/PluginUtils.java
@@ -187,6 +187,9 @@ public final class PluginUtils {
   }
 
   private static String getJenkinsfilePathFromFlowDefinition(CpsScmFlowDefinition flowDefinition) {
+
+    //TODO: Das hier kann man dazu nutzen, um das ""Jenkinsfile"" richtig zu benennen! dafür muss man es allerdings schon beim erstellen speichern (history.xml)
+    //TODO flowDefinition.getScriptPath()
     return flowDefinition.getScm().getKey();
   }
 

--- a/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/PluginUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/PluginUtils.java
@@ -187,9 +187,6 @@ public final class PluginUtils {
   }
 
   private static String getJenkinsfilePathFromFlowDefinition(CpsScmFlowDefinition flowDefinition) {
-
-    //TODO: Das hier kann man dazu nutzen, um das ""Jenkinsfile"" richtig zu benennen! dafür muss man es allerdings schon beim erstellen speichern (history.xml)
-    //TODO flowDefinition.getScriptPath()
     return flowDefinition.getScm().getKey();
   }
 

--- a/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/model/FilePipelineItemHistoryDao.java
+++ b/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/model/FilePipelineItemHistoryDao.java
@@ -50,11 +50,12 @@ import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.pipelineConfigHistory.DirectoryUtils;
 import org.jenkinsci.plugins.pipelineConfigHistory.PipelineConfigHistoryConsts;
 import org.jenkinsci.plugins.pipelineConfigHistory.PluginUtils;
+import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 import org.xml.sax.SAXException;
-import sun.rmi.runtime.Log;
 
 import static java.util.logging.Level.FINEST;
 import static java.util.logging.Level.WARNING;
@@ -183,7 +184,7 @@ public class FilePipelineItemHistoryDao implements PipelineItemHistoryDao {
           try {
             savePipelineHistoryDescriptionToXmlFile(
                 new PipelineHistoryDescription(oldDescr.getTimestamp(),
-                    workflowJob.getFullName(), oldDescr.getBuildNumber()
+                    workflowJob.getFullName(), oldDescr.getRootScriptName(), oldDescr.getBuildNumber()
                 ),
                 historyXml
             );
@@ -307,11 +308,18 @@ public class FilePipelineItemHistoryDao implements PipelineItemHistoryDao {
       copyRecursively(buildLibDir, new File(timestampedRootDir, "libs"));
     }
 
+    //get root script name
+    FlowDefinition flowDefinition = workflowJob.getDefinition();
+    String rootScriptName = (flowDefinition instanceof CpsScmFlowDefinition)
+        ? ((CpsScmFlowDefinition) flowDefinition).getScriptPath()
+        : "Jenkinsfile";
+
     //save history xml
     savePipelineHistoryDescriptionToXmlFile(
         new PipelineHistoryDescription(
             timestampedRootDir.getName(),
             workflowJob.getFullName(),
+            rootScriptName,
             buildNumber
         ),
         getHistoryXmlFile(timestampedRootDir)

--- a/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/model/PipelineHistoryDescription.java
+++ b/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/model/PipelineHistoryDescription.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.pipelineConfigHistory.model;
 import org.jenkinsci.plugins.pipelineConfigHistory.PluginUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 public class PipelineHistoryDescription {
@@ -36,16 +37,19 @@ public class PipelineHistoryDescription {
 
   private final int buildNumber;
 
+  private final String rootScriptName;
+
   /**
    * Get a PipelineHistoryDescription encapsulating the given information.
    * @param timestamp the config revision identifier
    * @param fullName the pipeline's full Name (jenkins convention)
    * @param buildNumber the build number associated to this config revision
    */
-  public PipelineHistoryDescription(String timestamp, String fullName, int buildNumber) {
+  public PipelineHistoryDescription(String timestamp, String fullName, String rootScript, int buildNumber) {
     this.timestamp = timestamp;
     this.fullName = fullName;
     this.buildNumber = buildNumber;
+    this.rootScriptName = rootScript;
   }
 
   public int getBuildNumber() {
@@ -58,6 +62,22 @@ public class PipelineHistoryDescription {
 
   public String getFullName() {
     return fullName;
+  }
+
+  public String getRootScriptName() {
+    return rootScriptName != null ? rootScriptName : "Jenkinsfile";
+  }
+
+  /**
+   * Get the root script filename
+   * @return the filename only (not the relative path)
+   */
+  public String getRootScriptSimpleName() {
+    return (rootScriptName != null)
+        ? Arrays.stream(rootScriptName.split("/"))
+            .reduce((first, second) -> second)
+            .orElse(rootScriptName)
+        : "Jenkinsfile";
   }
 
   public WorkflowJob getWorkflowJob() {

--- a/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryProjectAction/configOverview.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryProjectAction/configOverview.jelly
@@ -60,7 +60,7 @@
                             <td style="text-align:center">
                                 <j:choose>
                                     <j:when test="${realFile.getName().equals(&quot;build.xml&quot;)}">
-                                        <b>Jenkinsfile</b>
+                                        <b>${it.getPipelineHistoryDescription(timestamp).getRootScriptName()}</b>
                                         <br/>
                                         (Src:
                                         ${it.getJenkinsfilePath()})
@@ -73,7 +73,7 @@
                             <td>
                                 <j:choose>
                                     <j:when test="${realFile.getName().equals(&quot;build.xml&quot;)}">
-                                        <a class="download-arrow small" href="configSingleFile?timestamp=${timestamp}&amp;fileHash=${realFile.hashCode()}&amp;fileName=${fileNameDisplayAble}&amp;displayType=Jenkinsfile-raw" download="Jenkinsfile">
+                                        <a class="download-arrow small" href="configSingleFile?timestamp=${timestamp}&amp;fileHash=${realFile.hashCode()}&amp;fileName=${fileNameDisplayAble}&amp;displayType=Jenkinsfile-raw" download="${it.getPipelineHistoryDescription(timestamp).getRootScriptSimpleName()}">
                                             &#11015;
                                         </a>
                                     </j:when>

--- a/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryProjectAction/configSingleFile.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryProjectAction/configSingleFile.jelly
@@ -73,7 +73,7 @@
                                     <th>
                                         <j:choose>
                                             <j:when test="${displayType.equalsIgnoreCase(&quot;Jenkinsfile&quot;)}">
-                                                Jenkinsfile (Root Script)
+                                                ${it.getPipelineHistoryDescription(timestamp).getRootScriptName()} (Root Script)
                                                 <br/>
                                                 (Src:
                                                 ${it.getJenkinsfilePath()})
@@ -109,7 +109,7 @@
                     <j:choose>
                         <j:when test="${realFile.getName().equals(&quot;build.xml&quot;)}">
                             <div align="right">
-                                <a class="download-arrow big" href="configSingleFile?timestamp=${timestamp}&amp;fileHash=${realFile.hashCode()}&amp;fileName=${fileNameDisplayAble}&amp;displayType=Jenkinsfile-raw" download="Jenkinsfile">
+                                <a class="download-arrow big" href="configSingleFile?timestamp=${timestamp}&amp;fileHash=${realFile.hashCode()}&amp;fileName=${fileNameDisplayAble}&amp;displayType=Jenkinsfile-raw" download="${it.getPipelineHistoryDescription(timestamp).getRootScriptSimpleName()}">
                                     &#11015;
                                 </a>
                             </div>

--- a/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryProjectAction/showAllDiffs.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryProjectAction/showAllDiffs.jelly
@@ -89,7 +89,7 @@
                             <j:forEach var="match" items="${matches}">
                                 <j:choose>
                                     <j:when test="${match.getFileName().equals(&quot;build.xml&quot;)}">
-                                        <j:set var="subCaption" value="Jenkinsfile"></j:set>
+                                        <j:set var="subCaption" value="Root Script"></j:set>
                                     </j:when>
                                     <j:otherwise>
                                         <j:set var="subCaption" value="${match.getFile1().toString().replaceFirst(cuttingString1, &quot;&quot;)}"/>

--- a/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryProjectAction/showAllDiffs.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryProjectAction/showAllDiffs.jelly
@@ -108,12 +108,12 @@
                                                     ${subCaption}
                                                     <j:choose>
                                                         <j:when test="${match.getFileName().equals(&quot;build.xml&quot;)}">
-                                                            <a href="configSingleFile?timestamp=${timestamp2}&amp;fileHash=${match.getFile2().hashCode()}&amp;fileName=${fileNameDisplayAble}&amp;displayType=Jenkinsfile" style="text-decoration:none">
+                                                            <a href="configSingleFile?timestamp=${timestamp2}&amp;fileHash=${match.getFile2().hashCode()}&amp;fileName=${subCaption}&amp;displayType=Jenkinsfile" style="text-decoration:none">
                                                                 &#128279;
                                                             </a>
                                                         </j:when>
                                                         <j:otherwise>
-                                                            <a href="configSingleFile?timestamp=${timestamp2}&amp;fileHash=${match.getFile2().hashCode()}&amp;fileName=${fileNameDisplayAble}&amp;displayType=embedded" style="text-decoration:none">
+                                                            <a href="configSingleFile?timestamp=${timestamp2}&amp;fileHash=${match.getFile2().hashCode()}&amp;fileName=${subCaption}&amp;displayType=embedded" style="text-decoration:none">
                                                                 &#128279;
                                                             </a>
                                                         </j:otherwise>
@@ -201,12 +201,12 @@
                                                     file removed: ${subCaption}
                                                     <j:choose>
                                                         <j:when test="${match.getFileName().equals(&quot;build.xml&quot;)}">
-                                                            <a href="configSingleFile?timestamp=${timestamp1}&amp;fileHash=${match.getFile1().hashCode()}&amp;fileName=${fileNameDisplayAble}&amp;displayType=Jenkinsfile" style="text-decoration:none">
+                                                            <a href="configSingleFile?timestamp=${timestamp1}&amp;fileHash=${match.getFile1().hashCode()}&amp;fileName=${subCaption}&amp;displayType=Jenkinsfile" style="text-decoration:none">
                                                                 &#128279;
                                                             </a>
                                                         </j:when>
                                                         <j:otherwise>
-                                                            <a href="configSingleFile?timestamp=${timestamp1}&amp;fileHash=${match.getFile1().hashCode()}&amp;fileName=${fileNameDisplayAble}&amp;displayType=embedded" style="text-decoration:none">
+                                                            <a href="configSingleFile?timestamp=${timestamp1}&amp;fileHash=${match.getFile1().hashCode()}&amp;fileName=${subCaption}&amp;displayType=embedded" style="text-decoration:none">
                                                                 &#128279;
                                                             </a>
                                                         </j:otherwise>
@@ -271,12 +271,12 @@
                                                     file added: ${subCaption}
                                                     <j:choose>
                                                         <j:when test="${match.getFileName().equals(&quot;build.xml&quot;)}">
-                                                            <a href="configSingleFile?timestamp=${timestamp2}&amp;fileHash=${match.getFile2().hashCode()}&amp;fileName=${fileNameDisplayAble}&amp;displayType=Jenkinsfile" style="text-decoration:none">
+                                                            <a href="configSingleFile?timestamp=${timestamp2}&amp;fileHash=${match.getFile2().hashCode()}&amp;fileName=${subCaption}&amp;displayType=Jenkinsfile" style="text-decoration:none">
                                                                 &#128279;
                                                             </a>
                                                         </j:when>
                                                         <j:otherwise>
-                                                            <a href="configSingleFile?timestamp=${timestamp2}&amp;fileHash=${match.getFile2().hashCode()}&amp;fileName=${fileNameDisplayAble}&amp;displayType=embedded" style="text-decoration:none">
+                                                            <a href="configSingleFile?timestamp=${timestamp2}&amp;fileHash=${match.getFile2().hashCode()}&amp;fileName=${subCaption}&amp;displayType=embedded" style="text-decoration:none">
                                                                 &#128279;
                                                             </a>
                                                         </j:otherwise>

--- a/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryProjectAction/showDiffFiles.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryProjectAction/showDiffFiles.jelly
@@ -75,7 +75,7 @@
                                             <td class="unequal">
                                                 <j:choose>
                                                     <j:when test="${match.getFile1().getName().equals(&quot;build.xml&quot;)}">
-                                                        Jenkinsfile
+                                                        <b>Root Script:</b> ${it.getPipelineHistoryDescription(timestamp1).getRootScriptName()}
                                                         <a href="configSingleFile?timestamp=${timestamp1}&amp;fileHash=${match.getFile1().hashCode()}&amp;displayType=Jenkinsfile" style="text-decoration:none">
                                                             &#128279;
                                                         </a>
@@ -91,7 +91,7 @@
                                             <td class="unequal">
                                                 <j:choose>
                                                     <j:when test="${match.getFile2().getName().equals(&quot;build.xml&quot;)}">
-                                                        Jenkinsfile
+                                                        <b>Root Script:</b> ${it.getPipelineHistoryDescription(timestamp2).getRootScriptName()}
                                                         <a href="configSingleFile?timestamp=${timestamp2}&amp;fileHash=${match.getFile2().hashCode()}&amp;displayType=Jenkinsfile" style="text-decoration:none">
                                                             &#128279;
                                                         </a>

--- a/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryProjectAction/showSingleDiff.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryProjectAction/showSingleDiff.jelly
@@ -50,7 +50,7 @@
                     <j:set var="lines2" value="${it.getScriptFromXmlFile(timestamp2, fileHash2, false)}"/>
 
                     <j:set var="lines" value="${it.getLines(lines1, lines2)}"/>
-                    <j:set var="caption" value="Jenkinsfile-Diff"></j:set>
+                    <j:set var="caption" value="Root Script Diff"></j:set>
                 </j:when>
                 <j:otherwise>
 

--- a/src/test/java/org/jenkinsci/plugins/pipelineConfigHistory/model/FilePipelineItemHistoryDaoTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipelineConfigHistory/model/FilePipelineItemHistoryDaoTest.java
@@ -243,7 +243,7 @@ public class FilePipelineItemHistoryDaoTest {
 		assertEquals(
 				timestamp,
 				PluginUtils.getHistoryDao()
-						.getRevision(new PipelineHistoryDescription(timestamp, pipelineProject.getFullName(), 1))
+						.getRevision(new PipelineHistoryDescription(timestamp, pipelineProject.getFullName(), "", 1))
 						.getName()
 		);
 
@@ -253,7 +253,7 @@ public class FilePipelineItemHistoryDaoTest {
 		assertEquals(
 				timestamp,
 				PluginUtils.getHistoryDao()
-						.getRevision(new PipelineHistoryDescription(timestamp, pipelineProject.getFullName(), 1))
+						.getRevision(new PipelineHistoryDescription(timestamp, pipelineProject.getFullName(), "", 1))
 						.getName()
 		);
 	}

--- a/src/test/java/org/jenkinsci/plugins/pipelineConfigHistory/model/PipelineHistoryDescriptionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipelineConfigHistory/model/PipelineHistoryDescriptionTest.java
@@ -42,12 +42,12 @@ public class PipelineHistoryDescriptionTest {
 
 	@Test
 	public void getTimestamp() {
-		assertEquals(timestamp, new PipelineHistoryDescription(timestamp, fullName, 1).getTimestamp());
+		assertEquals(timestamp, new PipelineHistoryDescription(timestamp, fullName, "", 1).getTimestamp());
 	}
 
 	@Test
 	public void getFullName() {
-		assertEquals(fullName, new PipelineHistoryDescription(timestamp, fullName, 1).getFullName());
+		assertEquals(fullName, new PipelineHistoryDescription(timestamp, fullName, "", 1).getFullName());
 	}
 
 	@Test
@@ -55,6 +55,6 @@ public class PipelineHistoryDescriptionTest {
 		WorkflowJob workflowJob = new WorkflowJob(jenkinsRule.jenkins, fullName);
 		jenkinsRule.jenkins.add(workflowJob, fullName);
 
-		assertEquals(workflowJob, new PipelineHistoryDescription(timestamp, fullName, 1).getWorkflowJob());
+		assertEquals(workflowJob, new PipelineHistoryDescription(timestamp, fullName, "", 1).getWorkflowJob());
 	}
 }


### PR DESCRIPTION
Main script (pipeline entry points) used to always be called jenkinsfile.
This is fixed by a new entry in the history.xml.