### PR TITLE
Don't depend on pipeline aggregator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,9 +113,13 @@
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-aggregator</artifactId>
-            <!--This is the lowest version that will make a hello world pipeline build and also trigger the FlowExecutionListener.-->
-            <version>2.6</version>
+            <artifactId>workflow-job</artifactId>
+            <version>2.30</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>2.61</version>
         </dependency>
 
         <!--Non-Jenkins dependencies-->
@@ -135,18 +139,6 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>3.1.6</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>mailer</artifactId>
-            <version>1.20</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>script-security</artifactId>
-            <version>1.46</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/PipelineConfigHistoryConsts.java
+++ b/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/PipelineConfigHistoryConsts.java
@@ -74,11 +74,6 @@ public final class PipelineConfigHistoryConsts {
    */
   public static final String ID_FORMATTER = "yyyy-MM-dd_HH-mm-ss";
 
-  /**
-   * any plugins needed for this plugin to work should be listed here by their short names.
-   */
-  static final String[] REQUIRED_PLUGINS_SHORT_NAMES = {"workflow-aggregator"};
-
   public static final String LINK_SYMBOL = "\ud83d\udd17";
 
 }

--- a/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/PluginUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/PluginUtils.java
@@ -200,33 +200,6 @@ public final class PluginUtils {
   }
 
   /**
-   * Test if the required plugins are installed.
-   *
-   * @return whether the required plugins this plugin needs to work correctly are installed or not.
-   */
-  public static boolean requiredPluginsInstalled() {
-    return getMissingRequiredPlugins().equals("");
-  }
-
-  /**
-   * Get the missing required plugins as String.
-   *
-   * @return the missing required plugins.
-   */
-  public static String getMissingRequiredPlugins() {
-    List<PluginWrapper> plugins = Jenkins.get().getPluginManager().getPlugins();
-
-    HashSet<String> shortNames =
-        new HashSet<>(Arrays.asList(PipelineConfigHistoryConsts.REQUIRED_PLUGINS_SHORT_NAMES));
-
-    for (PluginWrapper pluginWrapper : plugins) {
-      String name = pluginWrapper.getShortName();
-      shortNames.remove(name);
-    }
-    return shortNames.isEmpty() ? "" : shortNames.toString();
-  }
-
-  /**
    * Test if the scripts contained in the two files are equal.
    *
    * @param xmlFile1 file1

--- a/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryActionFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryActionFactory.java
@@ -49,13 +49,6 @@ public class PipelineConfigHistoryActionFactory extends TransientActionFactory<W
   @Nonnull
   @Override
   public Collection<? extends Action> createFor(@Nonnull WorkflowJob abstractItem) {
-
-    if (!PluginUtils.requiredPluginsInstalled()) {
-      LOG.log(Level.WARNING, "Required plugins missing: "
-          + PluginUtils.getMissingRequiredPlugins());
-      return Collections.emptyList();
-    }
-
     final PipelineConfigHistoryProjectAction newAction = new PipelineConfigHistoryProjectAction(
         abstractItem);
 


### PR DESCRIPTION
Only depend on minimal set of pipeline components this plugin needs.

The aggregator plugin is just a convenience for users, but shouldn't be used as a dependency for other plugins.

I tried to keep the dependencies in the same vintage as selected by the aggregator (November 2018)

Additionally, I removed the IMHO unnecessary check for our own dependency - Jenkins' plugin manager should make sure this never happens