### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryProjectAction/showAllDiffs.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipelineConfigHistory/view/PipelineConfigHistoryProjectAction/showAllDiffs.jelly
@@ -73,7 +73,7 @@
                                                 <j:if test="${it.buildExists(buildNumber_olderChange)}">
                                                     <td style="width:40%; border:none; text-align:right; padding:0px">
                                                         <a class="describedElement" href="${rootURL}/job/${it.getProject().getFullName().replaceAll('/','/job/')}/${buildNumber_olderChange}/replay/" style="text-decoration:none">
-                                                            <img src="${rootURL}/images/24x24/redo.png"/>
+                                                            <l:icon class="icon-redo icon-md"/>
                                                             ${%Replay Build}
                                                             ${buildNumber_olderChange}
                                                         </a>
@@ -114,7 +114,7 @@
                                                 <j:if test="${it.buildExists(buildNumber_newerChange)}">
                                                     <td style="width:40%; border:none; text-align:right; padding:0px">
                                                         <a class="describedElement" href="${rootURL}/job/${it.getProject().getFullName().replaceAll('/','/job/')}/${buildNumber_newerChange}/replay/" style="text-decoration:none">
-                                                            <img src="${rootURL}/images/24x24/redo.png"/>
+                                                            <l:icon class="icon-redo icon-md"/>
                                                             ${%Replay Build}
                                                             ${buildNumber_newerChange}
                                                         </a>
@@ -303,7 +303,7 @@
                                                 <j:if test="${it.buildExists(buildNumber_olderChange)}">
                                                     <td style="width:40%; border:none; text-align:right; padding:0px">
                                                         <a class="describedElement" href="${rootURL}/job/${it.getProject().getFullName().replaceAll('/','/job/')}/${buildNumber_olderChange}/replay/" style="text-decoration:none">
-                                                            <img src="${rootURL}/images/24x24/redo.png"/>
+                                                            <l:icon class="icon-redo icon-md"/>
                                                             ${%Replay Build}
                                                             ${buildNumber_olderChange}
                                                         </a>
@@ -345,7 +345,7 @@
                                                 <j:if test="${it.buildExists(buildNumber_newerChange)}">
                                                     <td style="width:40%; border:none; text-align:right; padding:0px">
                                                         <a class="describedElement" href="${rootURL}/job/${it.getProject().getFullName().replaceAll('/','/job/')}/${buildNumber_newerChange}/replay/" style="text-decoration:none">
-                                                            <img src="${rootURL}/images/24x24/redo.png"/>
+                                                            <l:icon class="icon-redo icon-md"/>
                                                             ${%Replay Build}
                                                             ${buildNumber_newerChange}
                                                         </a>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.
In case of your plugin, I've removed the header icons, because that is what modern Jenkins does now look like.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @Jochen-A-Fuerbacher  
Thanks in advance!